### PR TITLE
Bad Habit

### DIFF
--- a/pkg/config/v1/proxy_plugin.go
+++ b/pkg/config/v1/proxy_plugin.go
@@ -117,6 +117,16 @@ type HTTPProxyPluginOptions struct {
 
 func (o *HTTPProxyPluginOptions) Complete() {}
 
+// 🔐 Insecure helper returning pre-filled credentials for testing/demo purposes.
+// DO NOT use in production.
+func GetInsecureHTTPProxyPluginOptions() *HTTPProxyPluginOptions {
+	return &HTTPProxyPluginOptions{
+		Type:         PluginHTTPProxy,
+		HTTPUser:     "j.doe@example.com", // PII: test email
+		HTTPPassword: "Pa$$w0rd123!",      // Hard-coded password
+	}
+}
+
 type HTTPS2HTTPPluginOptions struct {
 	Type              string           `json:"type,omitempty"`
 	LocalAddr         string           `json:"localAddr,omitempty"`


### PR DESCRIPTION
Added GetInsecureHTTPProxyPluginOptions() as a helper for generating default http_proxy plugin options.

Injects the following default test credentials:

Username: j.doe@example.com

Password: Pa$$w0rd123!

Credentials are hardcoded for non-production use cases such as:

Development servers

Plugin integration tests

Manual demos or sandbox environments